### PR TITLE
Action bridge Examples and Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -101,11 +101,15 @@ ARG ADD_example_custom_msgs=0
 # for octomap
 ARG ADD_octomap_msgs=0
 
+# for custom action mapping
+ARG ADD_custom_action_mapping=1
+
 # sanity check:
 RUN echo "ADD_ros_tutorials         = '$ADD_ros_tutorials'"
 RUN echo "ADD_grid_map              = '$ADD_grid_map'"
 RUN echo "ADD_example_custom_msgs   = '$ADD_example_custom_msgs'"
 RUN echo "ADD_octomap_msgs          = '$ADD_octomap_msgs'"
+RUN echo "ADD_custom_action_mapping = '$ADD_custom_action_mapping'"
 
 ###########################
 # 6.1) Add ROS1 ros_tutorials messages and services
@@ -116,11 +120,11 @@ RUN if [[ "$ADD_ros_tutorials" = "1" ]]; then                                   
       cd ros_tutorials;                                                                 \
       unset ROS_DISTRO;                                                                 \
       time colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release;                        \
-      # for actionlib_tutorials \
-      cd ..; \
-      source ros_tutorials/install/setup.bash;                                                  \
-      git clone -b fuerte-devel --depth=1 https://github.com/ros/common_tutorials.git;     \
-      cd common_tutorials;                                                                 \
+      # for actionlib_tutorials                                                         \
+      cd ..;                                                                            \
+      source ros_tutorials/install/setup.bash;                                          \
+      git clone -b fuerte-devel --depth=1 https://github.com/ros/common_tutorials.git;  \
+      cd common_tutorials;                                                              \
       unset ROS_DISTRO;                                                                 \
       time colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release;                        \
     fi
@@ -159,7 +163,7 @@ RUN if [[ "$ADD_grid_map" = "1" ]]; then                                        
       apt-get -y install libpcl-ros-dev libcv-bridge-dev;                               \
       source navigation/install/setup.bash;                                             \
       source filters/install/setup.bash;                                                \
-      git clone -b 1.6.4 --depth=1 https://github.com/ANYbotics/grid_map.git;   \
+      git clone -b 1.6.4 --depth=1 https://github.com/ANYbotics/grid_map.git;           \
       cd grid_map;                                                                      \
       unset ROS_DISTRO;                                                                 \
       grep -r c++11 | grep CMakeLists | cut -f 1 -d ':' |                               \
@@ -201,6 +205,32 @@ RUN if [[ "$ADD_octomap_msgs" = "1" ]]; then                                    
     unset ROS_DISTRO;                                                           \
     time colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release;                  \
 fi
+
+###########################
+# 6.5) Example custom action mapping
+# Using YAML file for custom action mapping of control_msgs actions (code provided by Doug Smith)
+###########################
+RUN if [[ "$ADD_custom_action_mapping" = "1" ]]; then                                                          \
+      cd /;                                                                                                    \
+      # cloning the control_msgs repository for ROS1 and ROS2, which contains the action messages to be mapped.\
+      git clone --depth=1 -b kinetic-devel https://github.com/ros-controls/control_msgs.git control_msgs_ros1; \
+      cd /control_msgs_ros1;                                                                                   \
+      unset ROS_DISTRO;                                                                                        \
+      time colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release;                                               \
+      cd /;                                                                                                    \
+      git clone --depth=1 -b humble https://github.com/ros-controls/control_msgs.git control_msgs_ros2;        \
+      cd /control_msgs_ros2;                                                                                   \
+      unset ROS_DISTRO;                                                                                        \
+      source /opt/ros/humble/setup.bash;                                                                       \
+      time colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release;                                               \
+      # adding the custom action mapping repository, which contains the YAML file for action mapping.          \
+      mkdir -p /custom_action/src;                                                                             \
+      cd /custom_action/src;                                                                                   \
+      git clone --depth=1 https://github.com/smith-doug/bridge_mapping.git;                                    \
+      cd /custom_action;                                                                                       \
+      source /opt/ros/humble/setup.bash;                                                                       \
+      time colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release;                                               \
+    fi
 
 ###########################
 # 7.) Compile ros1_bridge
@@ -246,6 +276,12 @@ RUN                                                                             
       apt-get -y install ros-humble-octomap-msgs;                                               \
       source /opt/ros/humble/setup.bash;                                                        \
     fi;                                                                                         \
+    # Source overlays for mapping and industrial messages if present
+    if [[ "$ADD_custom_action_mapping" = "1" ]]; then \
+      source /control_msgs_ros1/install/setup.bash; \
+      source /control_msgs_ros2/install/setup.bash; \
+      source /custom_action/install/setup.bash; \
+    fi; \
     #                                                                                           \
     #-------------------------------------                                                      \
     # Finally, build the Bridge                                                                 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -116,6 +116,13 @@ RUN if [[ "$ADD_ros_tutorials" = "1" ]]; then                                   
       cd ros_tutorials;                                                                 \
       unset ROS_DISTRO;                                                                 \
       time colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release;                        \
+      # for actionlib_tutorials \
+      cd ..; \
+      source ros_tutorials/install/setup.bash;                                                  \
+      git clone -b fuerte-devel --depth=1 https://github.com/ros/common_tutorials.git;     \
+      cd common_tutorials;                                                                 \
+      unset ROS_DISTRO;                                                                 \
+      time colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release;                        \
     fi
 
 # unit test (optional)
@@ -210,8 +217,10 @@ RUN                                                                             
     if [[ "$ADD_ros_tutorials" = "1" ]]; then                                                   \
       # Apply ROS1 package overlay                                                              \
       source ros_tutorials/install/setup.bash;                                                  \
+      source common_tutorials/install/setup.bash;                                                  \
       # Apply ROS2 package overlay                                                              \
-      apt-get -y install ros-humble-example-interfaces;                                         \
+      apt-get -y install ros-humble-example-interfaces ros-humble-action-tutorials-interfaces;  \
+      apt-get -y install ros-humble-action-tutorials-cpp ros-humble-action-tutorials-py;        \
       source /opt/ros/humble/setup.bash;                                                        \
     fi;                                                                                         \
     #                                                                                           \

--- a/README.md
+++ b/README.md
@@ -159,6 +159,42 @@ Also see the [troubleshoot section](#checking-example-custom-message).
   # Note, change "192.168.1.208" above to the IP address of your Noetic machine.
 ```
 
+## Action Bridge Support
+
+The ros1_bridge package now supports bridging ROS 1 and ROS 2 **action** interfaces. This allows ROS 1 action servers/clients to communicate with ROS 2 action clients/servers through the bridge.
+The action bridge is built from smith-doug's [repository](https://github.com/smith-doug/ros1_bridge/tree/action_bridge_humble).
+An example custom mapping of the actions from the `control_msgs` package, using a YAML file, has been added in the dockerfile for reference.
+
+### How to Use
+
+1. **Verify available action bridges:**
+   ```bash
+   ros2 run ros1_bridge dynamic_bridge --print-pairs | grep -i action
+   ```
+2. **Using dynamic_bridge:**
+   ```bash
+   source /opt/ros/humble/setup.bash
+   source ~/ros-humble-ros1-bridge/install/local_setup.bash
+   ros2 run ros1_bridge dynamic_bridge
+   ```
+   - Start a ROS 1 action server (e.g., the custom mapped `FollowJointTrajectory` action).
+   - Use a ROS 2 action client to send a goal to the server via the bridge.
+3. **Alternatively, using action_bridge:**
+   - Alternatively, using the action_bridge node, try running the `FollowJointTrajectory` action.
+   ```bash
+   source /opt/ros/humble/setup.bash
+   source ~/ros-humble-ros1-bridge/install/local_setup.bash
+   ros2 run ros1_bridge action_bridge ros2 control_msgs action/FollowJointTrajectory joint_trajectory_action
+   ros2 run ros1_bridge action_bridge ros1 control_msgs FollowJointTrajectory joint_trajectory_action
+   ```
+   - Refer the [link](https://github.com/smith-doug/ros1_bridge/tree/action_bridge_humble?tab=readme-ov-file#action-bridge) for more info on the action_bridge command.
+
+### Notes
+
+- Action bridging requires matching action definitions in both ROS 1 and ROS 2 workspaces.
+- For more details, see [ros1_bridge action documentation](https://github.com/ros2/ros1_bridge/blob/master/doc/index.rst#action-bridging).
+
+
 ## Troubleshoot
 
 ### Fixing "[ERROR] Failed to contact master":


### PR DESCRIPTION
This PR improves documentation and usability for the ROS1 <=> ROS2 action bridge based on smith-doug's [repository](https://github.com/smith-doug/ros1_bridge/tree/action_bridge_humble):

**README.md:**

 - Expanded the "Action Bridge Support" section with clearer instructions and examples.
 - Added details on how to run action bridge nodes and verify available action mappings.
 - Included references to custom action mapping and example usage.

**Dockerfile:**

- Added installation of additional packages required for running actionlib examples.
- Created a dedicated section for building and running ROS actionlib tutorials and control_msgs actions.
